### PR TITLE
Setup Vite dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ modules and source code will be added over time.
    ```bash
    firebase use --add
    ```
-3. Run any local development tools with `npm start` (currently a placeholder).
+3. Start the React development server:
+   ```bash
+   npm start
+   ```
+   This uses [Vite](https://vitejs.dev/) to serve the code in `app/`.
 
 ## License
 

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MarvLoan</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "MarvLoan project root",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "vite --config vite.config.ts",
+    "build": "vite build --config vite.config.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "license": "MIT",
@@ -16,5 +17,9 @@
     "i18next": "^23.8.0",
     "react-i18next": "^13.0.1"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.12"
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  root: 'app',
+  publicDir: 'public',
+  plugins: [react()],
+  build: {
+    outDir: '../dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- configure Vite for the React frontend
- add `@vitejs/plugin-react` and `vite` dev dependencies
- create `app/index.html` and update README to run the dev server

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(shows Vite server startup)*

------
https://chatgpt.com/codex/tasks/task_e_685845c72f78832eb1b745e57f2ef5ff