### PR TITLE
Simplify App routing

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,31 +1,16 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import Login from './features/auth/Login';
-import ForgotPassword from './features/auth/ForgotPassword';
-import UserList from './features/admin/UserList';
-import NoAccess from './components/NoAccess';
-import PrivateRoute from './components/PrivateRoute';
-import { AuthProvider } from './contexts/AuthContext';
 
-const App: React.FC = () => (
-  <AuthProvider>
+function App() {
+  return (
     <Router>
       <Routes>
+        <Route path="/" element={<Navigate to="/login" />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/forgot-password" element={<ForgotPassword />} />
-        <Route
-          path="/admin/users"
-          element={
-            <PrivateRoute roles={["Admin"]}>
-              <UserList />
-            </PrivateRoute>
-          }
-        />
-        <Route path="/no-access" element={<NoAccess />} />
-        <Route path="*" element={<Navigate to="/login" />} />
       </Routes>
     </Router>
-  </AuthProvider>
-);
+  );
+}
 
 export default App;


### PR DESCRIPTION
## Summary
- Simplify router to always redirect `/` to `/login`
- Only expose login page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685852eff9c4832e8c67920c78ded894